### PR TITLE
Use safe-buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,9 +46,10 @@ module.exports = function (metadata) {
     if (!handshake.metadata_size) {
       return this.emit('warning', new Error('Peer does not have metadata'))
     }
-
-    if (handshake.metadata_size > MAX_METADATA_SIZE) {
-      return this.emit('warning', new Error('Peer gave maliciously large metadata size'))
+    if (typeof handshake.metadata_size !== 'number' ||
+        MAX_METADATA_SIZE < handshake.metadata_size ||
+        handshake.metadata_size <= 0) {
+      return this.emit('warning', new Error('Peer gave invalid metadata size'))
     }
 
     this._metadataSize = handshake.metadata_size
@@ -200,8 +201,7 @@ module.exports = function (metadata) {
   }
 
   utMetadata.prototype._requestPieces = function () {
-    this.metadata = new Buffer(this._metadataSize)
-
+    this.metadata = Buffer.alloc(this._metadataSize)
     for (var piece = 0; piece < this._numPieces; piece++) {
       this._request(piece)
     }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "bitfield": "^1.0.1",
     "debug": "^2.2.0",
     "inherits": "^2.0.1",
+    "safe-buffer": "^5.0.1",
     "simple-sha1": "^2.0.0"
   },
   "devDependencies": {

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -4,8 +4,8 @@ var Protocol = require('bittorrent-protocol')
 var test = require('tape')
 var utMetadata = require('../')
 
-var id1 = new Buffer('01234567890123456789')
-var id2 = new Buffer('12345678901234567890')
+var id1 = Buffer.from('01234567890123456789')
+var id2 = Buffer.from('12345678901234567890')
 
 test('fetch()', function (t) {
   t.plan(3)


### PR DESCRIPTION
Use the new Buffer APIs from Node v6 for added security. For example,
`Buffer.from()` will throw if passed a number, unlike `Buffer()` which
allocated UNINITIALIZED memory in that case.

Use the `safe-buffer` package for compatibility with previous versions
of Node.js, including v4.x, v0.12, and v0.10.

https://github.com/feross/safe-buffer